### PR TITLE
Creator ID Rework

### DIFF
--- a/examples/journals.ts
+++ b/examples/journals.ts
@@ -11,7 +11,8 @@ async function main() {
     console.log(SEPARATOR);
     console.log("Creating a new journal...");
     const createResponse = await client.journals.create({ 
-      title: "My New Journal" 
+      title: "My New Journal"
+      // team_slug: "your-team-slug" // Optional: specify team_slug for team journals
     });
     console.log("Create Journal Response:");
     console.log(JSON.stringify(createResponse, null, 4));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opennote-ed/sdk",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Opennote TypeScript SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/api_types.ts
+++ b/src/api_types.ts
@@ -174,6 +174,7 @@ export interface GradeFRQResponse {
 export interface ImportFromMarkdownRequest {
   markdown: string;
   title?: string;
+  team_slug?: string;
 }
 
 export interface ImportFromMarkdownResponse {
@@ -213,17 +214,14 @@ export interface DeletedJournalData {
   content: string;
   comments: any[];
   created_at: string;
-  creator_id: string;
   is_trashed: boolean;
   trashed_at?: string;
   updated_at: string;
   font_family: string;
   parent_item?: string;
-  shared_users: string[];
   order_indexes?: any;
   publish_status: string;
   pending_invites?: any;
-  user_permissions: Record<string, string>;
   publish_subdomain: string;
 }
 
@@ -244,6 +242,7 @@ export interface ModelInfoResponse {
 // Create and Rename Journal Types
 export interface CreateJournalRequest {
   title: string;
+  team_slug?: string;
 }
 
 export interface CreateJournalResponse {
@@ -297,7 +296,7 @@ export type EditOperation =
 export interface EditJournalRequest {
   journal_id: string;
   operations: EditOperation[];
-  sync_realtime_state?: boolean; // Whether to directly update the state of the journal to all connected users. WARNING: Operations through synced states CANNOT be undone, and will remove Ctrl+Z functionality for all users for the changes made.
+  sync_realtime_state?: boolean;
 }
 
 export interface OperationResultData {

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,10 +90,11 @@ export class JournalEditor {
   constructor(private client: OpennoteClient) {}
 
   async importFromMarkdown(params: ImportFromMarkdownParams): Promise<ImportFromMarkdownResponse> {
-    const { markdown, title = "Imported Journal", extra_headers, extra_body } = params;
+    const { markdown, title = "Imported Journal", team_slug, extra_headers, extra_body } = params;
     const request: ImportFromMarkdownRequest = {
       markdown,
-      title
+      title,
+      team_slug
     };
 
     return this.client.request<ImportFromMarkdownResponse>(
@@ -161,9 +162,10 @@ export class Journals {
   }
 
   async create(params: CreateJournalParams): Promise<CreateJournalResponse> {
-    const { title, extra_headers, extra_body } = params;
+    const { title, team_slug, extra_headers, extra_body } = params;
     const request: CreateJournalRequest = {
-      title
+      title,
+      team_slug
     };
 
     return this.client.request<CreateJournalResponse>(

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -30,6 +30,7 @@ export interface VideoStatusParams {
 export interface ImportFromMarkdownParams {
   markdown: string;
   title?: string;
+  team_slug?: string;
   extra_headers?: Record<string, string>;
   extra_body?: Record<string, any>;
 }
@@ -55,6 +56,7 @@ export interface DeleteJournalParams {
 // Journals Schemas
 export interface CreateJournalParams {
   title: string;
+  team_slug?: string;
   extra_headers?: Record<string, string>;
   extra_body?: Record<string, any>;
 }


### PR DESCRIPTION
- **Add team_slug parameter to journal-related requests and examples**
- **bump ver**

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-01 21:08:08 UTC

<h3>Summary</h3>
This PR implements a "Creator ID Rework" that adds team-based journal management capabilities to the OpenNote API SDK. The primary change introduces an optional `team_slug` parameter to journal creation and markdown import operations, enabling users to create and manage journals within specific team contexts rather than just personal user contexts.

The implementation is comprehensive and well-integrated across the codebase:

- **Schema Updates**: Added `team_slug` as an optional parameter to `ImportFromMarkdownParams` and `CreateJournalParams` interfaces in `src/schemas.ts`
- **API Type Definitions**: Updated `ImportFromMarkdownRequest` and `CreateJournalRequest` interfaces in `src/api_types.ts` to include the `team_slug` field
- **Client Implementation**: Modified the client methods in `src/index.ts` to properly extract and pass the `team_slug` parameter to API requests
- **Documentation**: Updated the journal creation example in `examples/journals.ts` to show developers how to use the new team functionality
- **Data Model Cleanup**: Removed legacy creator-centric fields (`creator_id`, `shared_users`, `user_permissions`) from `DeletedJournalData`, indicating a shift from individual creator-based to team-based resource organization

This change represents a modern SaaS architecture pattern where resources belong to teams/organizations rather than individual users, enabling better multi-tenant support and collaborative workflows. The implementation maintains full backward compatibility since all new parameters are optional.

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| src/schemas.ts | 5/5 | Added optional `team_slug` parameter to journal creation and import interfaces |
| src/api_types.ts | 4/5 | Added `team_slug` to request types and removed legacy creator permission fields |
| src/index.ts | 5/5 | Implemented `team_slug` parameter extraction and passing in client methods |
| examples/journals.ts | 5/5 | Added commented example showing how to use `team_slug` for team journals |
| package.json | 5/5 | Version bump from 2.3.1 to 2.3.2 to reflect new functionality |

</details>

## Confidence score: 4/5

- This PR is safe to merge with low risk as it adds optional functionality without breaking existing contracts
- Score reflects solid implementation across all layers but slight concern about the data model changes in api_types.ts
- Pay close attention to src/api_types.ts for the removal of creator permission fields which could impact downstream consumers

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->